### PR TITLE
Check upower for the battery device and use line_power to check for AC

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: autopower
-Version: 0.95
+Version: 0.96
 Section: admin
 Priority: optional
 Architecture: amd64

--- a/usr/bin/autopower
+++ b/usr/bin/autopower
@@ -99,9 +99,13 @@ function set_power_profile() {
 
 #determine if the system is on AC power
 function on_ac_power() {
-    battery_state=$(upower -i /org/freedesktop/UPower/devices/battery_BAT0 | grep -m 1 state: | cut -d ':' -f 2)
+    battery_dev=$(upower -e | grep -m 1 battery)
+    battery_state=$(upower -i $battery_dev | grep -m 1 state: | cut -d ':' -f 2)
 
-    if [[ "$battery_state" == "               charging" || "$battery_state" == "               fully-charged" ]]; then
+    ac_dev=$(upower -e | grep -m 1 power)
+    ac_state=$(upower -i $ac_dev | grep -m 1 online: | cut -d ':' -f 2)
+
+    if [[ "$battery_state" == "               charging" || "$battery_state" == "               fully-charged" || "$ac_state" == "              yes" ]]; then
         return 0
     else
         return 1
@@ -226,7 +230,8 @@ function pause() {
 #get status of the daemon
 function status() {
     local current_profile=$(get_current_profile)
-    local battery_status=$(upower -i /org/freedesktop/UPower/devices/battery_BAT0 | grep -E "state" | awk '{print $2}')
+    local battery_dev=$(upower -e | grep -m 1 battery)
+    local battery_status=$(upower -i $battery_dev | grep -E "state" | awk '{print $2}')
     local timer_setting=$(grep -E "^OnUnitActiveSec" /etc/systemd/system/autopower.timer | awk -F'=' '{print $2}' | xargs)
 
     case "$current_profile" in


### PR DESCRIPTION
Running on the Framework laptop with Ubuntu 24.04 6.8.0-47-generic I noticed that it exposes the battery as BAT1 instead of BAT0. This patch checks upower for the device name. 

When throttling the max battery charge (e.g. only charge to 80%) upower never reports the battery fully-charged. This patch checks upower for a line_power device and checks for if the ac is online.